### PR TITLE
feat: add Bedrock Batch Inference sample

### DIFF
--- a/Industry Solutions/Software/BedrockBatchInference/README.md
+++ b/Industry Solutions/Software/BedrockBatchInference/README.md
@@ -1,0 +1,132 @@
+# Bedrock Batch Inference
+
+A minimal example showing how to orchestrate Amazon Bedrock batch inference with Lambda Durable Functions. Upload text files to S3, invoke the function, and it processes them all through Bedrock — **suspending at zero compute cost** while the job runs (minutes to hours), then resuming automatically when it completes.
+
+## Architecture
+
+```
+ ┌─────────────┐
+ │ .txt files  │  You upload >= 100 files to s3://bucket/inputs/
+ │ in S3       │
+ └──────┬──────┘
+        │
+┌───────▼──────────────────────────────────────────────────────────┐
+│  Durable Function (orchestrator)                                 │
+│                                                                  │
+│  1. List files in s3://bucket/inputs/                            │
+│  2. Read each file, apply prompt template, write JSONL           │
+│  3. Submit batch job to Bedrock                                  │
+│  4. wait_for_callback() ──── SUSPENDED (no compute) ────┐        │
+│  5. Read output, return results                         │        │
+└─────────────────────────────────────────────────────────┼────────┘
+                                                          │
+┌─────────────────────┐     ┌──────────────────────┐      │
+│  Amazon Bedrock     │────►│  EventBridge         │      │
+│  (batch inference)  │     │  (job state change)  │      │
+└─────────────────────┘     └──────────┬───────────┘      │
+                                       │                  │
+                            ┌──────────▼───────────┐      │
+                            │  Relay Lambda        │──────┘
+                            │  (sends callback)    │
+                            └──────────────────────┘
+```
+
+## How it works
+
+1. **List files** — Scans `s3://bucket/inputs/` for `.txt` files.
+
+2. **Build batch input** — Reads each file, wraps its content in a prompt template (`"Summarize the following text:\n\n{content}"`), and writes the batch as a JSONL file in Bedrock's [Converse format](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html).
+
+3. **Submit job** — Calls `CreateModelInvocationJob` with a `clientRequestToken` derived from the job ID (idempotent on retry).
+
+4. **Suspend** — `context.wait_for_callback()` persists the execution state and releases all compute. The Lambda is not running or billed during this time.
+
+5. **Resume** — When Bedrock finishes, it emits an EventBridge event. The relay Lambda looks up the callback ID from DynamoDB and calls `send_durable_execution_callback_success`, which resumes the orchestrator exactly where it left off.
+
+6. **Return results** — The orchestrator reads the output from S3 and returns a summary.
+
+## Deploy
+
+```bash
+sam build
+sam deploy --guided
+```
+
+## Upload files
+
+Upload at least 100 `.txt` files (Bedrock's non-adjustable minimum per job):
+
+```bash
+# Example: generate 100 sample files
+BUCKET=$(aws cloudformation describe-stacks \
+  --stack-name bedrock-batch-durable \
+  --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' \
+  --output text)
+
+for i in $(seq -w 1 100); do
+  echo "This is document $i about topic $i. It discusses various aspects..." \
+    | aws s3 cp - "s3://$BUCKET/inputs/doc-$i.txt"
+done
+```
+
+## Invoke
+
+```bash
+aws lambda invoke \
+  --function-name bedrock-batch-durable-orchestrator:live \
+  --invocation-type Event \
+  --durable-execution-name "batch-run-1" \
+  --payload '{}' \
+  --cli-binary-format raw-in-base64-out \
+  output.json
+```
+
+Or with a custom prefix and prompt:
+
+```bash
+aws lambda invoke \
+  --function-name bedrock-batch-durable-orchestrator:live \
+  --invocation-type Event \
+  --durable-execution-name "batch-run-2" \
+  --payload '{"prefix": "reports/", "max_tokens": 2048}' \
+  --cli-binary-format raw-in-base64-out \
+  output.json
+```
+
+The function returns immediately (async). It will complete once Bedrock finishes processing all files.
+
+## Key durable function concepts demonstrated
+
+| Concept | Where |
+|---------|-------|
+| `context.step()` — atomic, checkpointed operation | List files, build input, submit job, read output |
+| `context.wait_for_callback()` — suspend until external signal | Waiting for Bedrock job completion |
+| EventBridge → callback relay pattern | `callback_relay.py` bridges events to durable callbacks |
+| Idempotent submission | `clientRequestToken` prevents duplicate Bedrock jobs on replay |
+| Graceful error handling | `CallbackError` catch returns failure status instead of crashing |
+
+## Run tests
+
+```bash
+pip install -r requirements.txt
+pip install aws-durable-execution-sdk-python-testing pytest pytest-mock
+pytest test_batch_orchestrator.py -v
+```
+
+## Cleanup
+
+```bash
+BUCKET=$(aws cloudformation describe-stacks \
+  --stack-name bedrock-batch-durable \
+  --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' \
+  --output text)
+aws s3 rm "s3://$BUCKET" --recursive
+sam delete
+```
+
+## Cost
+
+- **Orchestrator compute**: ~5-10 seconds total (list + read files + submit + read output). Zero cost during the Bedrock wait.
+- **Relay Lambda**: One invocation per completed job (~100ms).
+- **Bedrock batch**: Billed per input/output token at the [batch pricing rate](https://aws.amazon.com/bedrock/pricing/) (typically 50% off on-demand).
+- **S3/DynamoDB**: Negligible for this sample.

--- a/Industry Solutions/Software/BedrockBatchInference/batch_orchestrator.py
+++ b/Industry Solutions/Software/BedrockBatchInference/batch_orchestrator.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2025 Amazon Web Services, Inc. or its affiliates.
+# All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""
+Bedrock Batch Inference orchestrator using Lambda Durable Functions.
+
+Processes text files from an S3 prefix: lists files, reads their content, packs
+them into a JSONL batch, submits to Bedrock, then suspends (zero compute cost)
+until the job completes via EventBridge callback.
+
+Demonstrates:
+  - context.step() for atomic operations (list files, build input, submit, read output)
+  - context.wait_for_callback() for async external-system integration
+  - EventBridge → callback relay pattern for event-driven resumption
+"""
+import json
+import os
+import uuid
+
+import boto3
+from aws_lambda_powertools import Logger
+
+from aws_durable_execution_sdk_python import DurableContext, durable_execution
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python.errors import CallbackError
+from aws_durable_execution_sdk_python.waits import WaitForCallbackConfig
+
+logger = Logger(service="bedrock-batch")
+
+bedrock = boto3.client("bedrock")
+s3 = boto3.client("s3")
+dynamodb = boto3.resource("dynamodb")
+
+BUCKET = os.environ["BUCKET"]
+INPUT_PREFIX = os.environ.get("INPUT_PREFIX", "inputs/")
+MODEL_ID = os.environ["MODEL_ID"]
+ROLE_ARN = os.environ["BEDROCK_ROLE_ARN"]
+CALLBACK_TABLE = os.environ["CALLBACK_TABLE"]
+PROMPT_TEMPLATE = os.environ.get(
+    "PROMPT_TEMPLATE", "Summarize the following text:\n\n{content}"
+)
+# Bedrock enforces a non-adjustable minimum of 100 records per batch job.
+MIN_RECORDS = 100
+
+
+@durable_execution
+def handler(event: dict, context: DurableContext) -> dict:
+    """Orchestrate a Bedrock batch inference job over text files in S3.
+
+    event:
+        prefix: str — S3 prefix containing .txt files (default: "inputs/")
+        max_tokens: int — max output tokens per record (default: 1024)
+    """
+    prefix = event.get("prefix", INPUT_PREFIX)
+    max_tokens = event.get("max_tokens", 1024)
+
+    # Step 1: List text files in the input prefix
+    files = context.step(
+        lambda _: list_input_files(prefix),
+        name="list-files",
+    )
+    context.logger.info(f"Found {len(files)} files in s3://{BUCKET}/{prefix}")
+
+    if len(files) < MIN_RECORDS:
+        raise ValueError(
+            f"Bedrock batch requires >= {MIN_RECORDS} files, found {len(files)}. "
+            f"Upload more .txt files to s3://{BUCKET}/{prefix}"
+        )
+
+    # Step 2: Generate a unique job ID
+    job_id = context.step(lambda _: str(uuid.uuid4()), name="generate-job-id")
+
+    # Step 3: Read files and write JSONL input to S3
+    record_count = context.step(
+        lambda _: build_batch_input(job_id, files, max_tokens),
+        name="build-input",
+    )
+    context.logger.info(f"Built batch input: {record_count} records")
+
+    # Step 4: Submit the Bedrock batch job
+    job_arn = context.step(lambda _: submit_job(job_id), name="submit-job")
+    context.logger.info(f"Submitted Bedrock job: {job_arn}")
+
+    # Step 5: Wait for Bedrock to finish (suspends — zero compute cost)
+    def register_callback(callback_id: str):
+        table = dynamodb.Table(CALLBACK_TABLE)
+        table.put_item(Item={"jobArn": job_arn, "callbackId": callback_id})
+
+    try:
+        bedrock_result = context.wait_for_callback(
+            submitter=register_callback,
+            config=WaitForCallbackConfig(timeout=Duration.from_hours(4)),
+            name="wait-for-bedrock",
+        )
+    except CallbackError as e:
+        context.logger.error(f"Bedrock job failed or timed out: {e}")
+        return {"jobId": job_id, "status": "failed", "error": str(e)}
+
+    context.logger.info(f"Bedrock job completed: {bedrock_result.get('status')}")
+
+    # Step 6: Read output from S3
+    output = context.step(lambda _: read_output(job_arn), name="read-output")
+
+    return {
+        "jobId": job_id,
+        "bedrockJobArn": job_arn,
+        "status": bedrock_result.get("status", "Completed"),
+        "filesProcessed": record_count,
+        "sampleOutput": output[:3],
+    }
+
+
+def list_input_files(prefix: str) -> list:
+    """List all .txt files under the given S3 prefix."""
+    files = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=BUCKET, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith(".txt"):
+                files.append(obj["Key"])
+    return sorted(files)
+
+
+def build_batch_input(job_id: str, file_keys: list, max_tokens: int) -> int:
+    """Read each text file from S3 and pack into a Converse-format JSONL."""
+    lines = []
+    for i, key in enumerate(file_keys):
+        content = s3.get_object(Bucket=BUCKET, Key=key)["Body"].read().decode("utf-8")
+        prompt = PROMPT_TEMPLATE.format(content=content)
+
+        record = {
+            "recordId": f"file-{i:05d}",
+            "modelInput": {
+                "messages": [
+                    {"role": "user", "content": [{"text": prompt}]}
+                ],
+                "inferenceConfig": {"maxTokens": max_tokens},
+            },
+        }
+        lines.append(json.dumps(record, separators=(",", ":")))
+
+    key = f"jobs/{job_id}/input.jsonl"
+    s3.put_object(Bucket=BUCKET, Key=key, Body="\n".join(lines).encode("utf-8"))
+    return len(lines)
+
+
+def submit_job(job_id: str) -> str:
+    """Submit the Bedrock batch inference job. Idempotent via clientRequestToken."""
+    response = bedrock.create_model_invocation_job(
+        jobName=f"durable-batch-{job_id[:8]}",
+        clientRequestToken=job_id.replace("-", ""),
+        modelId=MODEL_ID,
+        modelInvocationType="Converse",
+        roleArn=ROLE_ARN,
+        inputDataConfig={
+            "s3InputDataConfig": {
+                "s3Uri": f"s3://{BUCKET}/jobs/{job_id}/input.jsonl",
+                "s3InputFormat": "JSONL",
+            }
+        },
+        outputDataConfig={
+            "s3OutputDataConfig": {"s3Uri": f"s3://{BUCKET}/jobs/{job_id}/output/"}
+        },
+        timeoutDurationInHours=2,
+    )
+    return response["jobArn"]
+
+
+def read_output(job_arn: str) -> list:
+    """Read results from the Bedrock batch output location."""
+    job = bedrock.get_model_invocation_job(jobIdentifier=job_arn)
+    output_uri = job["outputDataConfig"]["s3OutputDataConfig"]["s3Uri"]
+
+    path = output_uri.replace("s3://", "")
+    bucket, prefix = path.split("/", 1)
+
+    results = []
+    response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    for obj in response.get("Contents", []):
+        if not obj["Key"].endswith(".jsonl.out"):
+            continue
+        body = s3.get_object(Bucket=bucket, Key=obj["Key"])["Body"].read().decode("utf-8")
+        for line in body.strip().split("\n"):
+            if line:
+                results.append(json.loads(line))
+
+    return results

--- a/Industry Solutions/Software/BedrockBatchInference/callback_relay.py
+++ b/Industry Solutions/Software/BedrockBatchInference/callback_relay.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2025 Amazon Web Services, Inc. or its affiliates.
+# All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""
+EventBridge → Durable Function callback relay.
+
+Triggered by EventBridge when a Bedrock batch inference job reaches a terminal
+state. Looks up the callback ID stored by the orchestrator and sends it to
+resume the durable execution.
+"""
+import json
+import os
+
+import boto3
+from aws_lambda_powertools import Logger
+from botocore.exceptions import ClientError
+
+logger = Logger(service="bedrock-batch-relay")
+
+lambda_client = boto3.client("lambda")
+dynamodb = boto3.resource("dynamodb")
+table = dynamodb.Table(os.environ["CALLBACK_TABLE"])
+
+
+def handler(event, context):
+    """Relay Bedrock job state-change events as durable callbacks.
+
+    EventBridge detail shape:
+        {"batchJobArn": "...", "status": "Completed|Failed|Expired|..."}
+    """
+    detail = event.get("detail", {})
+    job_arn = detail.get("batchJobArn")
+    status = detail.get("status", "")
+
+    if not job_arn:
+        logger.warning("No batchJobArn in event", extra={"event": event})
+        return {"sent": False, "reason": "no_job_arn"}
+
+    # Look up callback ID
+    item = table.get_item(Key={"jobArn": job_arn}).get("Item")
+    if not item:
+        logger.info("No callback mapping — not our job", extra={"jobArn": job_arn})
+        return {"sent": False, "reason": "not_tracked"}
+
+    callback_id = item["callbackId"]
+    payload = json.dumps({
+        "batchJobArn": job_arn,
+        "status": status,
+        "failureMessage": detail.get("failureMessage"),
+    })
+
+    try:
+        lambda_client.send_durable_execution_callback_success(
+            CallbackId=callback_id,
+            Payload=payload.encode("utf-8"),
+        )
+        logger.info("Callback sent", extra={"jobArn": job_arn, "status": status})
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code in ("ResourceNotFoundException", "InvalidParameterValueException"):
+            logger.warning("Callback expired or invalid", extra={"callbackId": callback_id})
+        else:
+            raise
+
+    # Cleanup (best-effort — TTL is the backstop)
+    try:
+        table.delete_item(Key={"jobArn": job_arn})
+    except ClientError:
+        pass
+
+    return {"sent": True, "jobArn": job_arn, "status": status}

--- a/Industry Solutions/Software/BedrockBatchInference/requirements.txt
+++ b/Industry Solutions/Software/BedrockBatchInference/requirements.txt
@@ -1,0 +1,3 @@
+aws-durable-execution-sdk-python>=0.1.0
+aws-lambda-powertools>=3.0.0
+boto3>=1.35.0

--- a/Industry Solutions/Software/BedrockBatchInference/samconfig.toml
+++ b/Industry Solutions/Software/BedrockBatchInference/samconfig.toml
@@ -1,0 +1,5 @@
+[default.deploy.parameters]
+stack_name = "bedrock-batch-durable"
+resolve_s3 = true
+capabilities = "CAPABILITY_IAM"
+confirm_changeset = true

--- a/Industry Solutions/Software/BedrockBatchInference/template.yaml
+++ b/Industry Solutions/Software/BedrockBatchInference/template.yaml
@@ -1,0 +1,186 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  Bedrock Batch Inference with Lambda Durable Functions.
+  Submits batch prompts, suspends during processing (zero cost), and resumes
+  on completion via EventBridge callback relay.
+
+Parameters:
+  ModelId:
+    Type: String
+    Default: anthropic.claude-sonnet-4-20250514-v1:0
+    Description: Bedrock model ID for batch inference
+  InputPrefix:
+    Type: String
+    Default: inputs/
+    Description: S3 prefix where .txt files are uploaded for processing
+  PromptTemplate:
+    Type: String
+    Default: "Summarize the following text:\n\n{content}"
+    Description: Prompt template applied to each file. Use {content} as placeholder.
+
+Globals:
+  Function:
+    Runtime: python3.13
+    Timeout: 30
+    MemorySize: 256
+    Architectures:
+      - arm64
+    Environment:
+      Variables:
+        LOG_LEVEL: INFO
+        POWERTOOLS_SERVICE_NAME: bedrock-batch
+
+Resources:
+
+  # ── S3 Bucket for batch I/O ──
+  BatchBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireJobData
+            Prefix: jobs/
+            Status: Enabled
+            ExpirationInDays: 7
+
+  # ── DynamoDB table mapping Bedrock job ARN → durable callback ID ──
+  CallbackTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: jobArn
+          AttributeType: S
+      KeySchema:
+        - AttributeName: jobArn
+          KeyType: HASH
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+
+  # ── IAM role for Bedrock to read/write S3 ──
+  BedrockServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: bedrock.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:ListBucket
+                Resource:
+                  - !GetAtt BatchBucket.Arn
+                  - !Sub "${BatchBucket.Arn}/*"
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource:
+                  - !Sub "${BatchBucket.Arn}/*"
+
+  # ── Orchestrator: the durable function ──
+  OrchestratorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-orchestrator"
+      Handler: batch_orchestrator.handler
+      MemorySize: 512
+      Timeout: 900
+      DurableConfig:
+        ExecutionTimeout: 28800  # 8 hours (covers Bedrock job runtime)
+        RetentionPeriodInDays: 3
+      AutoPublishAlias: live
+      Policies:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+        - S3CrudPolicy:
+            BucketName: !Ref BatchBucket
+        - DynamoDBCrudPolicy:
+            TableName: !Ref CallbackTable
+        - Statement:
+            - Effect: Allow
+              Action:
+                - bedrock:CreateModelInvocationJob
+                - bedrock:GetModelInvocationJob
+                - bedrock:ListModelInvocationJobs
+              Resource: "*"
+            - Effect: Allow
+              Action: iam:PassRole
+              Resource: !GetAtt BedrockServiceRole.Arn
+      Environment:
+        Variables:
+          BUCKET: !Ref BatchBucket
+          INPUT_PREFIX: !Ref InputPrefix
+          MODEL_ID: !Ref ModelId
+          BEDROCK_ROLE_ARN: !GetAtt BedrockServiceRole.Arn
+          CALLBACK_TABLE: !Ref CallbackTable
+          PROMPT_TEMPLATE: !Ref PromptTemplate
+
+  # ── Relay: forwards EventBridge events as durable callbacks ──
+  RelayFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-relay"
+      Handler: callback_relay.handler
+      Timeout: 30
+      MemorySize: 128
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref CallbackTable
+        - Statement:
+            - Effect: Allow
+              Action:
+                - lambda:SendDurableExecutionCallbackSuccess
+                - lambda:SendDurableExecutionCallbackFailure
+              Resource:
+                - !GetAtt OrchestratorFunction.Arn
+                - !Sub "${OrchestratorFunction.Arn}:*"
+      Environment:
+        Variables:
+          CALLBACK_TABLE: !Ref CallbackTable
+      Events:
+        BedrockJobComplete:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              source:
+                - aws.bedrock
+              detail-type:
+                - "Batch Inference Job State Change"
+              detail:
+                status:
+                  - Completed
+                  - PartiallyCompleted
+                  - Failed
+                  - Stopped
+                  - Expired
+
+Outputs:
+  OrchestratorArn:
+    Description: Orchestrator function ARN (use :live alias to invoke)
+    Value: !GetAtt OrchestratorFunction.Arn
+  OrchestratorAlias:
+    Description: Qualified ARN for invocation
+    Value: !Sub "${OrchestratorFunction.Arn}:live"
+  BucketName:
+    Description: S3 bucket for batch I/O
+    Value: !Ref BatchBucket
+  InvokeCommand:
+    Description: Example invocation command
+    Value: !Sub >
+      aws lambda invoke
+      --function-name ${OrchestratorFunction.Arn}:live
+      --invocation-type Event
+      --durable-execution-name "batch-run-1"
+      --payload '{}'
+      --cli-binary-format raw-in-base64-out
+      output.json

--- a/Industry Solutions/Software/BedrockBatchInference/test_batch_orchestrator.py
+++ b/Industry Solutions/Software/BedrockBatchInference/test_batch_orchestrator.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2025 Amazon Web Services, Inc. or its affiliates.
+# All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""
+Tests for Bedrock Batch Inference durable function.
+"""
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aws_durable_execution_sdk_python_testing import InvocationStatus
+
+
+@pytest.fixture(autouse=True)
+def mock_env(monkeypatch):
+    monkeypatch.setenv("BUCKET", "test-bucket")
+    monkeypatch.setenv("INPUT_PREFIX", "inputs/")
+    monkeypatch.setenv("MODEL_ID", "anthropic.claude-sonnet-4-20250514-v1:0")
+    monkeypatch.setenv("BEDROCK_ROLE_ARN", "arn:aws:iam::123456789012:role/test")
+    monkeypatch.setenv("CALLBACK_TABLE", "test-callbacks")
+    monkeypatch.setenv("PROMPT_TEMPLATE", "Summarize:\n\n{content}")
+    monkeypatch.setenv("POWERTOOLS_SERVICE_NAME", "bedrock-batch")
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+
+@pytest.fixture
+def mock_aws():
+    """Mock all AWS service calls."""
+    with patch("batch_orchestrator.s3") as mock_s3, \
+         patch("batch_orchestrator.bedrock") as mock_bedrock, \
+         patch("batch_orchestrator.dynamodb") as mock_dynamodb:
+
+        # list_objects_v2 returns 100 .txt files
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"Contents": [{"Key": f"inputs/doc-{i:03d}.txt"} for i in range(100)]}
+        ]
+        mock_s3.get_paginator.return_value = mock_paginator
+
+        # get_object for reading file content
+        mock_s3.get_object.return_value = {
+            "Body": MagicMock(
+                read=MagicMock(return_value=b"This is a sample document about cloud computing.")
+            )
+        }
+
+        # list_objects_v2 for reading output (non-paginated call)
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [{"Key": "jobs/abc/output/results.jsonl.out"}]
+        }
+
+        mock_bedrock.create_model_invocation_job.return_value = {
+            "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-123"
+        }
+        mock_bedrock.get_model_invocation_job.return_value = {
+            "outputDataConfig": {
+                "s3OutputDataConfig": {"s3Uri": "s3://test-bucket/jobs/abc/output/"}
+            }
+        }
+
+        mock_table = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+
+        yield {
+            "s3": mock_s3,
+            "bedrock": mock_bedrock,
+            "dynamodb": mock_dynamodb,
+            "table": mock_table,
+        }
+
+
+class TestBatchOrchestrator:
+    """Test the durable function orchestrator."""
+
+    @pytest.mark.durable_execution(
+        handler="batch_orchestrator.handler",
+        lambda_function_name="test-orchestrator",
+    )
+    def test_happy_path(self, durable_runner, mock_aws):
+        """Full flow: list files → build input → submit → callback → read output."""
+        with durable_runner:
+            execution_future = durable_runner.run_async(input={}, timeout=30)
+
+            time.sleep(0.2)
+            callback_op = durable_runner.get_operation("wait-for-bedrock")
+            callback_op.send_callback_success(json.dumps({
+                "batchJobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-123",
+                "status": "Completed",
+            }))
+
+            result = execution_future.result(timeout=10)
+
+        assert result.status is InvocationStatus.SUCCEEDED
+        assert result.result["status"] == "Completed"
+        assert result.result["filesProcessed"] == 100
+
+        # Verify batch input was written to S3
+        mock_aws["s3"].put_object.assert_called_once()
+        call_kwargs = mock_aws["s3"].put_object.call_args[1]
+        assert call_kwargs["Key"].startswith("jobs/")
+        assert call_kwargs["Key"].endswith("/input.jsonl")
+
+    @pytest.mark.durable_execution(
+        handler="batch_orchestrator.handler",
+        lambda_function_name="test-orchestrator",
+    )
+    def test_job_failure_handled_gracefully(self, durable_runner, mock_aws):
+        """Bedrock job fails — function returns error status, doesn't crash."""
+        with durable_runner:
+            execution_future = durable_runner.run_async(input={}, timeout=30)
+
+            time.sleep(0.2)
+            callback_op = durable_runner.get_operation("wait-for-bedrock")
+            callback_op.send_callback_failure("JobFailed", "Model error")
+
+            result = execution_future.result(timeout=10)
+
+        assert result.status is InvocationStatus.SUCCEEDED
+        assert result.result["status"] == "failed"
+
+    @pytest.mark.durable_execution(
+        handler="batch_orchestrator.handler",
+        lambda_function_name="test-orchestrator",
+    )
+    def test_too_few_files_raises(self, durable_runner, mock_aws):
+        """Fewer than 100 files raises ValueError."""
+        # Override to return only 50 files
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"Contents": [{"Key": f"inputs/doc-{i:03d}.txt"} for i in range(50)]}
+        ]
+        mock_aws["s3"].get_paginator.return_value = mock_paginator
+
+        with durable_runner:
+            result = durable_runner.run(input={}, timeout=10)
+
+        assert result.status is InvocationStatus.FAILED
+        assert "100 files" in str(result.error)
+
+
+class TestCallbackRelay:
+    """Test the EventBridge callback relay."""
+
+    def test_relay_sends_callback(self):
+        with patch("callback_relay.table") as mock_table, \
+             patch("callback_relay.lambda_client") as mock_lambda:
+            mock_table.get_item.return_value = {
+                "Item": {"jobArn": "arn:aws:bedrock:...:job/abc", "callbackId": "cb-123"}
+            }
+
+            from callback_relay import handler
+            result = handler(
+                {"detail": {"batchJobArn": "arn:aws:bedrock:...:job/abc", "status": "Completed"}},
+                None,
+            )
+
+            assert result["sent"] is True
+            mock_lambda.send_durable_execution_callback_success.assert_called_once()
+
+    def test_relay_ignores_unknown_jobs(self):
+        with patch("callback_relay.table") as mock_table:
+            mock_table.get_item.return_value = {}
+
+            from callback_relay import handler
+            result = handler(
+                {"detail": {"batchJobArn": "arn:aws:bedrock:...:job/unknown", "status": "Completed"}},
+                None,
+            )
+
+            assert result["sent"] is False
+            assert result["reason"] == "not_tracked"


### PR DESCRIPTION
## Summary

Adds a new sample under **Industry Solutions/Software/BedrockBatchInference** demonstrating how to orchestrate Amazon Bedrock batch inference with Lambda Durable Functions.

## What it does

1. Lists `.txt` files from an S3 prefix
2. Reads each file, applies a configurable prompt template, packs into JSONL
3. Submits a Bedrock batch inference job
4. **Suspends at zero compute cost** via `wait_for_callback()`
5. Resumes when Bedrock completes (EventBridge → relay Lambda → durable callback)
6. Returns results

## Key patterns demonstrated

- `context.step()` — atomic checkpointed operations
- `context.wait_for_callback()` — async external-system integration (hours-long wait, no billing)
- EventBridge → callback relay pattern for event-driven resumption
- Idempotent job submission via `clientRequestToken`
- Graceful error handling (`CallbackError` catch)

## Files

| File | Purpose |
|------|---------|
| `batch_orchestrator.py` | The durable function (187 lines) |
| `callback_relay.py` | EventBridge → callback bridge (71 lines) |
| `template.yaml` | SAM deployment (full infrastructure) |
| `test_batch_orchestrator.py` | Pytest with durable test SDK |
| `README.md` | Walkthrough with architecture diagram |

## Testing

```bash
pip install -r requirements.txt
pip install aws-durable-execution-sdk-python-testing pytest pytest-mock
pytest test_batch_orchestrator.py -v
```
